### PR TITLE
Update config external services name

### DIFF
--- a/content/config.md
+++ b/content/config.md
@@ -4,7 +4,7 @@
 An app's *config* is everything that is likely to vary between [deploys](./codebase.md) (staging, production, developer environments, etc).  This includes:
 
 * Resource handles to the database, Memcached, and other [backing services](./backing-services.md)
-* Credentials to external services such as Amazon S3 or Twitter
+* Credentials to external services such as Amazon S3 or X (formerly Twitter)
 * Per-deploy values such as the canonical hostname for the deploy
 
 Apps sometimes store config as constants in the code.  This is a violation of twelve-factor, which requires **strict separation of config from code**.  Config varies substantially across deploys, code does not.


### PR DESCRIPTION
Since Twitter's company name is now X.