### PR TITLE
Changing Thin URL

### DIFF
--- a/content/port-binding.md
+++ b/content/port-binding.md
@@ -7,7 +7,7 @@ Web apps are sometimes executed inside a webserver container.  For example, PHP 
 
 In a local development environment, the developer visits a service URL like `http://localhost:5000/` to access the service exported by their app.  In deployment, a routing layer handles routing requests from a public-facing hostname to the port-bound web processes.
 
-This is typically implemented by using [dependency declaration](./dependencies.md) to add a webserver library to the app, such as [Tornado](http://www.tornadoweb.org/) for Python, [Thin](http://code.macournoyer.com/thin/) for Ruby, or [Jetty](http://www.eclipse.org/jetty/) for Java and other JVM-based languages.  This happens entirely in *user space*, that is, within the app's code.  The contract with the execution environment is binding to a port to serve requests.
+This is typically implemented by using [dependency declaration](./dependencies.md) to add a webserver library to the app, such as [Tornado](http://www.tornadoweb.org/) for Python, [Thin](https://github.com/macournoyer/thin) for Ruby, or [Jetty](http://www.eclipse.org/jetty/) for Java and other JVM-based languages.  This happens entirely in *user space*, that is, within the app's code.  The contract with the execution environment is binding to a port to serve requests.
 
 HTTP is not the only service that can be exported by port binding.  Nearly any kind of server software can be run via a process binding to a port and awaiting incoming requests.  Examples include [ejabberd](http://www.ejabberd.im/) (speaking [XMPP](http://xmpp.org/)), and [Redis](http://redis.io/) (speaking the [Redis protocol](http://redis.io/topics/protocol)).
 


### PR DESCRIPTION
Previous Thin URL was not working, so I'm linking its Github page, as it might be the most adequate in this case.